### PR TITLE
Restyle IT-IT UI with beauty-tech light theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,15 @@ from tkinter import ttk
 from activity_log import describe_event, get_recent_events, log_event, register_listener
 from config_manager import get_active_profile_name
 from ui import (
+    ACCENT,
+    BASE_BG,
+    DANGER,
+    INFO_ACCENT,
+    PANEL_BG,
+    POSITIVE,
+    SECONDARY_ACCENT,
+    TEXT_MUTED,
+    TEXT_PRIMARY,
     build_agile_section,
     build_sap_section,
     build_telco_section,
@@ -40,31 +49,32 @@ def create_main_gui() -> None:
     root = tk.Tk()
     root.title("IT ! IT - Modern Admin Toolkit")
 
-    base_bg = '#1a1d29'
-    panel_bg = '#242837'
-    accent = '#60a5fa'
-    positive = '#34d399'
-    info_bg = '#3b82f6'
-    danger_bg = '#f87171'
-    text_primary = '#f1f5f9'
-    text_muted = '#94a3b8'
-
-    root.configure(bg=base_bg)
+    root.configure(bg=BASE_BG)
 
     style = ttk.Style()
     style.theme_use('clam')
-    style.configure('MainTech.TFrame', background=base_bg, relief='flat')
-    style.configure('MainTech.TLabelframe', background=panel_bg, foreground=accent, borderwidth=0, relief='flat', padding=24)
-    style.configure('MainTech.TLabelframe.Label', background=panel_bg, foreground=accent, font=('Segoe UI', 11, 'bold'))
-    style.configure('MainTechButton.TButton', background=positive, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('MainTechButton.TButton', background=[('active', '#059669'), ('pressed', '#047857')], relief=[('pressed', 'flat')])
-    style.configure('InfoButton.TButton', background=info_bg, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('InfoButton.TButton', background=[('active', '#0284c7'), ('pressed', '#0369a1')])
-    style.configure('DangerButton.TButton', background=danger_bg, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('DangerButton.TButton', background=[('active', '#dc2626'), ('pressed', '#b91c1c')])
-    style.configure('MainTech.TNotebook', background=base_bg, borderwidth=0)
-    style.configure('MainTech.TNotebook.Tab', background=panel_bg, foreground=text_primary, padding=(18, 10), font=('Segoe UI', 10, 'bold'))
-    style.map('MainTech.TNotebook.Tab', background=[('selected', accent)], foreground=[('selected', '#0f172a')])
+    style.configure('MainTech.TFrame', background=BASE_BG, relief='flat')
+    style.configure('MainTech.TLabelframe', background=PANEL_BG, foreground=ACCENT, borderwidth=0, relief='flat', padding=24)
+    style.configure('MainTech.TLabelframe.Label', background=PANEL_BG, foreground=ACCENT, font=('Segoe UI', 11, 'bold'))
+    style.configure('MainTechButton.TButton', background=POSITIVE, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
+    style.map(
+        'MainTechButton.TButton',
+        background=[('active', '#68B491'), ('pressed', '#5AA884')],
+        relief=[('pressed', 'flat')],
+    )
+    style.configure('InfoButton.TButton', background=INFO_ACCENT, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
+    style.map(
+        'InfoButton.TButton',
+        background=[('active', '#887BFF'), ('pressed', '#7766F6')],
+    )
+    style.configure('DangerButton.TButton', background=DANGER, foreground='#ffffff', borderwidth=0, padding=(20, 14), font=('Segoe UI', 10, 'bold'), relief='flat')
+    style.map(
+        'DangerButton.TButton',
+        background=[('active', '#D07A77'), ('pressed', '#C06764')],
+    )
+    style.configure('MainTech.TNotebook', background=BASE_BG, borderwidth=0)
+    style.configure('MainTech.TNotebook.Tab', background=PANEL_BG, foreground=TEXT_MUTED, padding=(18, 10), font=('Segoe UI', 10, 'bold'))
+    style.map('MainTech.TNotebook.Tab', background=[('selected', ACCENT)], foreground=[('selected', '#ffffff')])
 
     screen_width, screen_height = root.winfo_screenwidth(), root.winfo_screenheight()
     window_width = min(max(800, int(screen_width * 0.7)), 1200)
@@ -84,10 +94,10 @@ def create_main_gui() -> None:
 
     status_message_var = tk.StringVar(value="Ready")
 
-    content_container = tk.Frame(root, bg=base_bg)
+    content_container = tk.Frame(root, bg=BASE_BG)
     content_container.pack(fill='both', expand=True)
 
-    main_canvas = tk.Canvas(content_container, bg=base_bg, highlightthickness=0)
+    main_canvas = tk.Canvas(content_container, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(content_container, orient='vertical', command=main_canvas.yview)
     scrollable_frame = ttk.Frame(main_canvas, style='MainTech.TFrame')
 
@@ -122,13 +132,21 @@ def create_main_gui() -> None:
 
     header = ttk.Frame(scrollable_frame, style='MainTech.TFrame')
     header.pack(fill='x', pady=(20, 40))
-    tk.Label(header, text=ASCII_BANNER, font=('Consolas', 5), bg=base_bg, fg='#ff6b6b', justify='center').pack()
-    tk.Label(header, text='// INGRASYS IT ADMIN AUTOMATION TOOLKIT', font=('Segoe UI', 14, 'bold'), bg=base_bg, fg=text_primary).pack(pady=(10, 2))
-    tk.Label(header, text='// COLLAB WITH CODEX&CLAUDE', font=('Segoe UI', 10), bg=base_bg, fg=text_muted).pack()
+    tk.Label(header, text=ASCII_BANNER, font=('Consolas', 5), bg=BASE_BG, fg=SECONDARY_ACCENT, justify='center').pack()
+    tk.Label(header, text='// INGRASYS IT ADMIN AUTOMATION TOOLKIT', font=('Segoe UI', 14, 'bold'), bg=BASE_BG, fg=TEXT_PRIMARY).pack(pady=(10, 2))
+    tk.Label(header, text='// COLLAB WITH CODEX&CLAUDE', font=('Segoe UI', 10), bg=BASE_BG, fg=TEXT_MUTED).pack()
 
-    status_frame = tk.Frame(header, bg=base_bg)
+    status_frame = tk.Frame(header, bg=BASE_BG)
     status_frame.pack(pady=(15, 0))
-    status_label = tk.Label(status_frame, font=('Segoe UI', 9), bg='#1e3a2e', fg='#34d399', padx=16, pady=6, relief='flat')
+    status_label = tk.Label(
+        status_frame,
+        font=('Segoe UI', 9),
+        bg='#EEF6F3',
+        fg=POSITIVE,
+        padx=16,
+        pady=6,
+        relief='flat',
+    )
     status_label.pack()
 
     def refresh_online_badge() -> None:
@@ -177,12 +195,12 @@ def create_main_gui() -> None:
 
             header_frame = ttk.Frame(self.container, style='MainTech.TFrame')
             header_frame.pack(fill='x', pady=(0, 12))
-            tk.Label(header_frame, text='📜 Recent Activity Log', font=('Segoe UI', 14, 'bold'), bg=base_bg, fg=text_primary).pack(side='left')
+            tk.Label(header_frame, text='📜 Recent Activity Log', font=('Segoe UI', 14, 'bold'), bg=BASE_BG, fg=TEXT_PRIMARY).pack(side='left')
             ttk.Button(header_frame, text='Refresh', style='InfoButton.TButton', command=self.refresh).pack(side='right')
 
-            body = tk.Frame(self.container, bg=panel_bg, highlightthickness=0)
+            body = tk.Frame(self.container, bg=PANEL_BG, highlightthickness=0)
             body.pack(fill='both', expand=True)
-            self.text = tk.Text(body, bg=panel_bg, fg=text_primary, insertbackground=accent, font=('Consolas', 10), wrap='word', borderwidth=0, relief='flat', state='disabled')
+            self.text = tk.Text(body, bg=PANEL_BG, fg=TEXT_PRIMARY, insertbackground=ACCENT, font=('Consolas', 10), wrap='word', borderwidth=0, relief='flat', state='disabled')
             self.text.pack(side='left', fill='both', expand=True)
             scrollbar_inner = ttk.Scrollbar(body, orient='vertical', command=self.text.yview)
             scrollbar_inner.pack(side='right', fill='y')
@@ -242,11 +260,11 @@ def create_main_gui() -> None:
     register_listener(on_log_entry)
     log_event('ui', 'Operator console launched', details={'profile': active_profile_var.get()})
 
-    status_bar = tk.Frame(root, bg=panel_bg)
+    status_bar = tk.Frame(root, bg=PANEL_BG)
     status_bar.pack(fill='x', side='bottom')
-    tk.Label(status_bar, textvariable=environment_display_var, font=('Segoe UI', 10, 'bold'), bg=panel_bg, fg=accent).pack(side='left', padx=16, pady=8)
-    tk.Label(status_bar, textvariable=status_message_var, font=('Segoe UI', 9), bg=panel_bg, fg=text_primary, anchor='w').pack(side='left', padx=12)
-    tk.Label(status_bar, text='Press ESC to exit • Use ⚙ Settings to manage configuration', font=('Segoe UI', 9), bg=panel_bg, fg=text_muted).pack(side='right', padx=16)
+    tk.Label(status_bar, textvariable=environment_display_var, font=('Segoe UI', 10, 'bold'), bg=PANEL_BG, fg=ACCENT).pack(side='left', padx=16, pady=8)
+    tk.Label(status_bar, textvariable=status_message_var, font=('Segoe UI', 9), bg=PANEL_BG, fg=TEXT_PRIMARY, anchor='w').pack(side='left', padx=12)
+    tk.Label(status_bar, text='Press ESC to exit • Use ⚙ Settings to manage configuration', font=('Segoe UI', 9), bg=PANEL_BG, fg=TEXT_MUTED).pack(side='right', padx=16)
 
     root.after(100, initialize_window)
     root.mainloop()

--- a/design_prompt.md
+++ b/design_prompt.md
@@ -1,0 +1,70 @@
+# Beauty-Tech UI/UX Redesign Brief for IT-IT
+
+Craft a refreshed interface for **IT-IT**, the internal IT administrator cockpit that orchestrates onboarding, access management, SAP automations, and telco billing. Preserve every existing workflow and automation—this is a purely visual and experiential uplift inspired by modern beauty-tech products: light, refined, and delightfully precise.
+
+## Product Context
+
+- **Primary modules**: User Management, SAP S/4HANA Integrations (creation, support, disable flows), Agile account maintenance, monthly telco processing, and configuration settings.
+- **Power users**: IT analysts who perform repetitive tasks daily and need an environment that feels calm, trustworthy, and efficient for long sessions.
+- **Platform**: Desktop-first Tkinter application. Keep layouts practical for 1280px and wider screens while remaining legible on smaller laptop resolutions.
+
+## Experience Pillars
+
+1. **Luminous Tech Elegance** – Blend clinical precision with the warmth of beauty labs. Surfaces should feel weightless with translucent touches, soft gradients, and subtle metallic accents.
+2. **Effortless Control** – Highlight hierarchy, give breathing space, and maintain predictable component behavior so power users can act quickly without relearning flows.
+3. **Nurturing Feedback** – Every status change, progress indicator, or validation state should reassure and guide without shouting.
+
+## Visual Language
+
+- **Palette**: Base the theme on soft neutrals (`#F9F6FB`, `#FFFFFF`), blush undertones (`#F5E6EF`), and muted metallic highlights (rose-gold `#D9A5B3`, champagne `#EADCCF`). Use a cool tech accent (`#8AA7FF`) and a balancing mint (`#7CC3A2`) for confirmations. Reserve a calmer coral (`#E69896`) for destructive states. Ensure contrast meets WCAG AA on all text and controls.
+- **Typography**: Use a contemporary sans-serif (e.g., Segoe UI, Inter) with airy line spacing. Pair with a high-legibility serif or stylized sans for headings (weight 600–700) to introduce a beauty editorial tone without sacrificing readability.
+- **Iconography & Illustrations**: Prefer line-based icons with softened corners and rose-gold strokes. When space allows, introduce micro-illustrations referencing skincare vials, waveforms, or glowing particles to reinforce the beauty-tech mood.
+- **Depth & Materials**: Employ glassmorphism-inspired layers: frosted cards, drop shadows with wide blur and low opacity, and gradient hairlines to separate sections. Avoid stark black outlines; instead, rely on gentle borders and glow effects.
+
+## Layout Guidance by Module
+
+### Global Shell
+- Anchor navigation on the left with a translucent rail containing module icons and labels. The active section should glow subtly with the accent gradient.
+- Persist a top information bar that shows the active environment profile, quick status messages, and access to settings.
+- Wrap each module in generous padding (24–32px) and maintain consistent spacing tokens (4/8/12/20/32).
+
+### User Management
+- Present core actions as elevated cards with contextual descriptions (“Create New User Email”, “Disable User Email Access”). Cards should react with a soft halo on hover and switch to solid accent backgrounds on press.
+- The batch entry dialog should resemble a modern form studio: stacked inputs with floating labels, pastel focus rings, and a sticky summary sidebar that lists queued users with pill-shaped chips.
+
+### SAP Integration (Creation, Support, Disable)
+- Use step-based layouts with progress breadcrumbs to communicate complex flows. Each step card can feature subtle laboratory-inspired imagery (e.g., data molecules) in the corner.
+- Confirmation prompts should surface as centered glass panels with supportive copy and primary actions in the mint accent.
+- Display parsed Excel results inside scrollable tables with zebra striping using blush tints for alternating rows.
+
+### Agile Account Flows
+- Mirror the SAP visual treatment but introduce an electric lavender accent for Agile-specific buttons to differentiate context.
+- Highlight ticket requirements with inline badges and tooltips that feel like delicate sticky notes.
+
+### Telco Billing
+- Present monthly processing as a timeline card showing past executions. When a run completes, animate a cascading shimmer across the card to celebrate.
+- Keep file selection areas bright with dashed rose-gold borders and iconography representing PDFs and folders.
+
+### Settings & Profiles
+- Frame the configuration notebook as a studio palette: frosted background, pill tabs, and clear descriptions above each form group.
+- Use monospaced text sparingly (only where users expect raw configuration values). Prefer the main sans-serif elsewhere for cohesion.
+
+## Interaction & Feedback
+
+- **Motion**: Limit animation durations to 200–280 ms. Use easing curves that feel fluid (cubic-bezier 0.25, 0.8, 0.5, 1). Animations should emphasize state change: button hover glow, card elevation, progress shimmer.
+- **Notifications**: Toasts slide up from the lower right with translucent backgrounds and softly blurred shadows. Include iconography that matches the outcome (success mint check, info lavender spark, warning champagne triangle).
+- **Progress**: Replace spinning indicators with linear gradients or particle flows that convey forward momentum.
+
+## Accessibility & Inclusivity
+
+- Guarantee minimum 4.5:1 contrast for text against backgrounds; test accent-on-white combinations and provide darker fallback tokens when necessary.
+- Offer a “high contrast” toggle that deepens accents and reinforces outlines without abandoning the beauty-tech theme.
+- Ensure keyboard focus rings are evident (e.g., mint outer glow) and never rely solely on color to differentiate states.
+
+## Deliverables
+
+- High-fidelity mockups covering every module, modals, empty states, error states, and responsive behavior at 1280px and 1440px widths.
+- Interactive prototype demonstrating key workflows: new user batch creation, SAP onboarding review, Agile reset, M1 telco run, and configuration edits.
+- Updated component library (Figma or similar) documenting foundations (color, type, spacing), states, motion references, and usage guidelines so developers can implement the theme without altering existing logic.
+
+Adhere strictly to current functionality while transforming the visual identity into a light, polished, beauty-tech experience that calms operators and underscores the sophistication of IT-IT’s automations.

--- a/ui.py
+++ b/ui.py
@@ -36,20 +36,20 @@ from email_service import (
     send_m1_telco_email,
 )
 
-# Balanced Dark Theme - Professional & Easy to Read
-BASE_BG = '#1a1d29'  # Soft dark blue-gray (not too dark)
-PANEL_BG = '#242837'  # Slightly lighter panels for depth
-INPUT_BG = '#2d3548'  # Medium dark for inputs (good contrast)
-ACCENT = '#60a5fa'  # Bright blue (high contrast)
-SECONDARY_ACCENT = '#34d399'  # Bright mint green
-POSITIVE = '#34d399'  # Bright green
-INFO_ACCENT = '#3b82f6'  # Vibrant blue
-WARNING = '#fbbf24'  # Bright yellow
-DANGER = '#f87171'  # Bright coral red
-TEXT_PRIMARY = '#f1f5f9'  # Almost white text for readability
-TEXT_MUTED = '#94a3b8'  # Light gray for secondary text
-BORDER_COLOR = '#334155'  # Subtle borders
-SHADOW_COLOR = '#0f1419'  # Deep shadow
+# Beauty-Tech Inspired Light Theme
+BASE_BG = '#F9F6FB'  # Airy neutral base
+PANEL_BG = '#FFFFFF'  # Clean cards and panels
+INPUT_BG = '#FDF8FB'  # Soft blush input fields
+ACCENT = '#8AA7FF'  # Cool tech accent
+SECONDARY_ACCENT = '#D9A5B3'  # Rose-gold highlight
+POSITIVE = '#7CC3A2'  # Mint confirmation tone
+INFO_ACCENT = '#9E8CFF'  # Lavender info tone
+WARNING = '#F4C989'  # Champagne warning tone
+DANGER = '#E69896'  # Calm coral for destructive actions
+TEXT_PRIMARY = '#2F2635'  # Deep plum text
+TEXT_MUTED = '#6F6475'  # Muted lilac-gray secondary text
+BORDER_COLOR = '#E8DBEC'  # Gentle divider
+SHADOW_COLOR = '#E4D7EA'  # Diffused shadow
 from user_workflow import generate_user_workbooks
 from sap_workflows import (
     build_preview_window,
@@ -171,7 +171,10 @@ def build_multiuser_form(root: tk.Tk, title: str, labels: List[str], submit_hand
     style.configure('Tech.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Segoe UI', 10))
     style.configure('Tech.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, borderwidth=1, insertcolor=ACCENT, font=('Segoe UI', 10), relief='flat')
     style.configure('TechButton.TButton', background=POSITIVE, foreground='#ffffff', borderwidth=0, padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('TechButton.TButton', background=[('active', '#059669'), ('pressed', '#047857')])
+    style.map(
+        'TechButton.TButton',
+        background=[('active', '#68B491'), ('pressed', '#5AA884')],
+    )
 
     canvas = tk.Canvas(form, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(form, orient="vertical", command=canvas.yview)
@@ -440,8 +443,11 @@ def launch_sap_support():
     style.configure('Support.TLabelframe.Label', background=PANEL_BG, foreground=ACCENT, font=('Segoe UI', 11, 'bold'))
     style.configure('Support.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Segoe UI', 10))
     style.configure('Support.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, insertcolor=ACCENT, font=('Segoe UI', 10), borderwidth=1, relief='flat')
-    style.configure('SupportButton.TButton', background=POSITIVE, foreground='#1a1d29', padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('SupportButton.TButton', background=[('active', '#2dd4a3'), ('pressed', '#1fb885')])
+    style.configure('SupportButton.TButton', background=POSITIVE, foreground='#ffffff', padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
+    style.map(
+        'SupportButton.TButton',
+        background=[('active', '#68B491'), ('pressed', '#5AA884')],
+    )
 
     canvas = tk.Canvas(support_window, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(support_window, orient='vertical', command=canvas.yview)
@@ -597,7 +603,10 @@ def launch_sap_disable():
     style.configure('Disable.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Segoe UI', 10))
     style.configure('Disable.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, insertcolor=ACCENT, font=('Segoe UI', 10), borderwidth=1, relief='flat')
     style.configure('DisableButton.TButton', background=DANGER, foreground='#ffffff', padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('DisableButton.TButton', background=[('active', '#ef4444'), ('pressed', '#dc2626')])
+    style.map(
+        'DisableButton.TButton',
+        background=[('active', '#D07A77'), ('pressed', '#C06764')],
+    )
 
     canvas = tk.Canvas(disable_window, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(disable_window, orient='vertical', command=canvas.yview)
@@ -861,7 +870,10 @@ def launch_agile_creation() -> None:
     style.configure('Agile.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Segoe UI', 10))
     style.configure('Agile.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, insertcolor=ACCENT, font=('Segoe UI', 10), borderwidth=1, relief='flat')
     style.configure('AgileButton.TButton', background=POSITIVE, foreground='#ffffff', padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('AgileButton.TButton', background=[('active', '#059669'), ('pressed', '#047857')])
+    style.map(
+        'AgileButton.TButton',
+        background=[('active', '#68B491'), ('pressed', '#5AA884')],
+    )
 
     canvas = tk.Canvas(window, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(window, orient='vertical', command=canvas.yview)
@@ -1107,7 +1119,10 @@ def launch_agile_reset() -> None:
     style.configure('AgileReset.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Segoe UI', 10))
     style.configure('AgileReset.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, insertcolor=ACCENT, font=('Segoe UI', 10), borderwidth=1, relief='flat')
     style.configure('AgileResetButton.TButton', background=DANGER, foreground='#ffffff', padding=(14, 10), font=('Segoe UI', 10, 'bold'), relief='flat')
-    style.map('AgileResetButton.TButton', background=[('active', '#ef4444'), ('pressed', '#dc2626')])
+    style.map(
+        'AgileResetButton.TButton',
+        background=[('active', '#D07A77'), ('pressed', '#C06764')],
+    )
 
     canvas = tk.Canvas(window, bg=BASE_BG, highlightthickness=0)
     scrollbar = ttk.Scrollbar(window, orient='vertical', command=canvas.yview)
@@ -1571,7 +1586,7 @@ def show_settings_dialog(root: tk.Tk) -> None:
     dialog = tk.Toplevel(root)
     dialog.title("Settings")
     dialog.geometry("780x600")
-    dialog.configure(bg='#1e1e1e')
+    dialog.configure(bg=BASE_BG)
 
     style = ttk.Style(dialog)
     style.configure('Settings.TFrame', background=BASE_BG)
@@ -1580,7 +1595,11 @@ def show_settings_dialog(root: tk.Tk) -> None:
     style.configure('Settings.TLabelframe.Label', background=PANEL_BG, foreground=ACCENT, font=('Consolas', 11, 'bold'))
     style.configure('Settings.TLabel', background=PANEL_BG, foreground=TEXT_PRIMARY, font=('Consolas', 10))
     style.configure('Settings.TEntry', fieldbackground=INPUT_BG, foreground=TEXT_PRIMARY, insertcolor=ACCENT, font=('Consolas', 10))
-    style.configure('SettingsButton.TButton', background=POSITIVE, foreground='#0f172a', padding=(12, 8), font=('Consolas', 11, 'bold'))
+    style.configure('SettingsButton.TButton', background=POSITIVE, foreground='#ffffff', padding=(12, 8), font=('Consolas', 11, 'bold'))
+    style.map(
+        'SettingsButton.TButton',
+        background=[('active', '#68B491'), ('pressed', '#5AA884')],
+    )
 
     active_profile = get_active_profile_name()
     profile_var = tk.StringVar(value=active_profile)
@@ -1612,7 +1631,7 @@ def show_settings_dialog(root: tk.Tk) -> None:
     notebook_container = ttk.Frame(dialog, style='Settings.TFrame')
     notebook_container.pack(fill='both', expand=True, padx=15, pady=15)
 
-    notebook_canvas = tk.Canvas(notebook_container, bg='#1e1e1e', highlightthickness=0)
+    notebook_canvas = tk.Canvas(notebook_container, bg=BASE_BG, highlightthickness=0)
     notebook_scrollbar = ttk.Scrollbar(notebook_container, orient='vertical', command=notebook_canvas.yview)
     notebook_canvas.pack(side='left', fill='both', expand=True)
     notebook_scrollbar.pack(side='right', fill='y')
@@ -1702,7 +1721,7 @@ def show_settings_dialog(root: tk.Tk) -> None:
     backups_list.pack(fill='both', expand=True, padx=12, pady=(0, 12))
 
     status_var = tk.StringVar()
-    status_label = ttk.Label(dialog, textvariable=status_var, foreground='#58a6ff', background='#1e1e1e', font=('Consolas', 10))
+    status_label = ttk.Label(dialog, textvariable=status_var, foreground=ACCENT, background=BASE_BG, font=('Consolas', 10))
     status_label.pack(fill='x', padx=15, pady=(0, 5))
 
     def populate_fields(profile_name: str) -> None:


### PR DESCRIPTION
## Summary
- replace the generic beauty-tech prompt with an IT-IT specific redesign brief highlighting each workflow
- refresh theme constants and component styles in the Tkinter UI to introduce a light, beauty-tech palette without touching logic
- update the main application shell to reuse the shared palette, polish headers, and align feedback areas with the new look

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e5d7d86440832e8eed55ea1900f08b